### PR TITLE
Add express middleware to log accesses

### DIFF
--- a/dist/lib/bunyan-logger.js
+++ b/dist/lib/bunyan-logger.js
@@ -32,6 +32,27 @@ var logger = function loggerFunc(name, filePath, logToConsole) {
   return logger;
 };
 
+var middleware = function middleware(loggerInstance) {
+  return function accessLogMiddleware(req, res, next) {
+    // This doesn't fire the log immediately, but waits until the response is finished
+    // This means we have a chance of logging the response code
+    res.on("finish", function () {
+      loggerInstance.info({
+        remoteAddress: req.ip,
+        method: req.method,
+        url: req.originalUrl,
+        protocol: req.protocol,
+        hostname: req.hostname,
+        httpVersion: req.httpVersionMajor + "." + req.httpVersionMinor,
+        userAgent: req.headers["user-agent"],
+        status: res._header ? res.statusCode : undefined
+      }, "access_log");
+    });
+    next();
+  };
+};
+
 module.exports = {
-  logger: logger
+  logger: logger,
+  middleware: middleware
 };

--- a/src/lib/bunyan-logger.js
+++ b/src/lib/bunyan-logger.js
@@ -32,6 +32,27 @@ const logger = function loggerFunc(name, filePath, logToConsole) {
   return logger;
 };
 
+const middleware = function (loggerInstance) {
+  return function accessLogMiddleware(req, res, next) {
+    // This doesn't fire the log immediately, but waits until the response is finished
+    // This means we have a chance of logging the response code
+    res.on("finish", () => {
+      loggerInstance.info({
+        remoteAddress: req.ip,
+        method: req.method,
+        url: req.originalUrl,
+        protocol: req.protocol,
+        hostname: req.hostname,
+        httpVersion: `${req.httpVersionMajor}.${req.httpVersionMinor}`,
+        userAgent: req.headers["user-agent"],
+        status: res._header ? res.statusCode : undefined
+      }, "access_log");
+    });
+    next();
+  };
+};
+
 module.exports = {
-  logger: logger
+  logger: logger,
+  middleware: middleware
 };


### PR DESCRIPTION
Best to centralise this so that we can easily change the log format across all services.